### PR TITLE
Add Procfile for Nixpacks deployment

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 duckdb
 pydantic
+httpx


### PR DESCRIPTION
## Summary
- add Procfile with uvicorn start command
- include httpx in requirements for tests

## Testing
- `pip install -r requirements.txt` *(failed: Could not find a version that satisfies the requirement httpx (403 Forbidden))*
- `pytest` *(failed: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_688f598d09348324acc7093d4cec2730