### PR TITLE
Add file upload endpoint for DuckDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ This is a minimal FastAPI application that exposes a RESTful interface for execu
         -d '{"sql": "SELECT 1"}'
    ```
 
+4. **Upload data**
+   ```bash
+   curl -X POST http://localhost:8000/upload \\
+        -F "file=@path/to/data.csv" \\
+        -F "table_name=your_table" \\
+        -F "primary_key=id"
+   ```
+   The endpoint accepts CSV or Parquet files. If the table exists, the data
+   is merged using the supplied primary key; otherwise a new table is created.
+
 ## Environment Variables
 
 - `DATABASE_PATH` – Path to a DuckDB file on a persistent Railway volume.

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,11 @@
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, UploadFile, File, Form
 from pydantic import BaseModel
 from app.db import get_connection
+import os
+import tempfile
+import shutil
+import re
+from pathlib import Path
 
 app = FastAPI()
 
@@ -22,3 +27,66 @@ def run_query(request: QueryRequest):
         return {"columns": columns, "rows": rows}
     except Exception as exc:
         raise HTTPException(status_code=400, detail=str(exc))
+
+
+
+@app.post("/upload")
+async def upload_table(
+    file: UploadFile = File(...),
+    table_name: str = Form(...),
+    primary_key: str | None = Form(None),
+) -> dict:
+    """Upload a CSV or Parquet file and merge it into a DuckDB table."""
+
+    if not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", table_name):
+        raise HTTPException(status_code=400, detail="Invalid table name")
+
+    suffix = Path(file.filename or "").suffix.lower()
+    if suffix not in {".csv", ".parquet"}:
+        raise HTTPException(status_code=400, detail="Only .csv and .parquet files are supported")
+
+    with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
+        shutil.copyfileobj(file.file, tmp)
+        tmp_path = tmp.name
+
+    read_func = "read_csv_auto" if suffix == ".csv" else "read_parquet"
+
+    conn = get_connection()
+    try:
+        table_exists = (
+            conn.execute(
+                "SELECT COUNT(*) FROM information_schema.tables WHERE table_name=?",
+                [table_name],
+            ).fetchone()[0]
+            > 0
+        )
+
+        if not table_exists:
+            conn.execute(
+                f"CREATE TABLE {table_name} AS SELECT * FROM {read_func}('{tmp_path}')"
+            )
+            if primary_key:
+                pk_cols = ", ".join(c.strip() for c in primary_key.split(","))
+                conn.execute(
+                    f"ALTER TABLE {table_name} ADD PRIMARY KEY ({pk_cols})"
+                )
+        else:
+            if not primary_key:
+                raise HTTPException(
+                    status_code=400, detail="primary_key is required for upsert"
+                )
+            conn.execute(
+                f"INSERT OR REPLACE INTO {table_name} SELECT * FROM {read_func}('{tmp_path}')"
+            )
+
+        row_count = conn.execute(
+            f"SELECT COUNT(*) FROM {table_name}"
+        ).fetchone()[0]
+        return {"table": table_name, "rows": row_count}
+    except HTTPException:
+        raise
+    except Exception as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=400, detail=str(exc))
+    finally:
+        conn.close()
+        os.unlink(tmp_path)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ uvicorn
 duckdb
 pydantic
 httpx
+python-multipart

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -28,3 +28,45 @@ def test_query_parquet(tmp_path):
     )
     assert response.status_code == 200
     assert response.json()["rows"] == [[1]]
+
+
+def test_upload_and_merge(tmp_path):
+    os.environ["DATABASE_PATH"] = str(tmp_path / "db.duckdb")
+
+    csv1 = b"id,name\n1,Alice\n2,Bob\n"
+    files = {"file": ("people.csv", csv1, "text/csv")}
+    data = {"table_name": "people", "primary_key": "id"}
+    resp1 = client.post("/upload", files=files, data=data)
+    assert resp1.status_code == 200
+    assert resp1.json()["rows"] == 2
+
+    csv2 = b"id,name\n2,Bobby\n3,Charlie\n"
+    files = {"file": ("people.csv", csv2, "text/csv")}
+    data = {"table_name": "people", "primary_key": "id"}
+    resp2 = client.post("/upload", files=files, data=data)
+    assert resp2.status_code == 200
+
+    query_resp = client.post(
+        "/query", json={"sql": "SELECT * FROM people ORDER BY id"}
+    )
+    assert query_resp.status_code == 200
+    assert query_resp.json()["rows"] == [
+        [1, "Alice"],
+        [2, "Bobby"],
+        [3, "Charlie"],
+    ]
+
+
+def test_upload_requires_primary_key(tmp_path):
+    os.environ["DATABASE_PATH"] = str(tmp_path / "db.duckdb")
+
+    csv = b"id,name\n1,Alice\n"
+    files = {"file": ("people.csv", csv, "text/csv")}
+    data = {"table_name": "people", "primary_key": "id"}
+    resp1 = client.post("/upload", files=files, data=data)
+    assert resp1.status_code == 200
+
+    files = {"file": ("people.csv", csv, "text/csv")}
+    data = {"table_name": "people"}
+    resp2 = client.post("/upload", files=files, data=data)
+    assert resp2.status_code == 400


### PR DESCRIPTION
## Summary
- handle CSV/Parquet uploads using FastAPI `UploadFile` and form fields
- validate table names and expose primary-key-based upserts
- document `/upload` usage in the README and add test coverage for missing primary key

## Testing
- `python -m pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement python-multipart)*
- `pytest` *(fails: RuntimeError: Form data requires "python-multipart" to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_688f8c7b317c8324a7fc9177b9c1c71c