### PR TITLE
Return query results as object array

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,11 @@ This is a minimal FastAPI application that exposes a RESTful interface for execu
    ```bash
    curl -X POST http://localhost:8000/query \\
         -H 'Content-Type: application/json' \\
-        -d '{"sql": "SELECT 1"}'
+        -d '{"sql": "SELECT 1 AS one"}'
+   ```
+   The response will be an array of objects:
+   ```json
+   [{"one": 1}]
    ```
 
 4. **Upload data**

--- a/app/main.py
+++ b/app/main.py
@@ -21,12 +21,13 @@ def run_query(request: QueryRequest):
     try:
         conn = get_connection(request.source, request.path)
         cursor = conn.execute(request.sql)
-        rows = cursor.fetchall()
         columns = [desc[0] for desc in cursor.description]
-        conn.close()
-        return {"columns": columns, "rows": rows}
+        rows = cursor.fetchall()
+        return [dict(zip(columns, row)) for row in rows]
     except Exception as exc:
         raise HTTPException(status_code=400, detail=str(exc))
+    finally:
+        conn.close()
 
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -10,9 +10,7 @@ client = TestClient(app)
 def test_query_duckdb():
     response = client.post("/query", json={"sql": "SELECT 42 AS answer"})
     assert response.status_code == 200
-    data = response.json()
-    assert data["rows"] == [[42]]
-    assert data["columns"] == ["answer"]
+    assert response.json() == [{"answer": 42}]
 
 
 def test_query_parquet(tmp_path):
@@ -27,7 +25,7 @@ def test_query_parquet(tmp_path):
         },
     )
     assert response.status_code == 200
-    assert response.json()["rows"] == [[1]]
+    assert response.json() == [{"id": 1}]
 
 
 def test_upload_and_merge(tmp_path):
@@ -52,10 +50,10 @@ def test_upload_and_merge(tmp_path):
         "/query", json={"sql": "SELECT * FROM people ORDER BY id"}
     )
     assert query_resp.status_code == 200
-    assert query_resp.json()["rows"] == [
-        [1, "Alice"],
-        [2, "Bobby"],
-        [3, "Charlie"],
+    assert query_resp.json() == [
+        {"id": 1, "name": "Alice"},
+        {"id": 2, "name": "Bobby"},
+        {"id": 3, "name": "Charlie"},
     ]
 
 
@@ -81,10 +79,10 @@ def test_upload_skips_blank_primary_key(tmp_path):
         "/query", json={"sql": "SELECT * FROM people ORDER BY id"}
     )
     assert query_resp.status_code == 200
-    assert query_resp.json()["rows"] == [
-        [1, "Alice"],
-        [2, "Bobby"],
-        [3, "Charlie"],
+    assert query_resp.json() == [
+        {"id": 1, "name": "Alice"},
+        {"id": 2, "name": "Bobby"},
+        {"id": 3, "name": "Charlie"},
     ]
 
 
@@ -122,9 +120,9 @@ def test_upload_and_merge_composite_key(tmp_path):
         "/query", json={"sql": "SELECT * FROM people ORDER BY id, subid"}
     )
     assert query_resp.status_code == 200
-    assert query_resp.json()["rows"] == [
-        [1, 1, "Alice"],
-        [2, 1, "Bobby"],
-        [3, 1, "Charlie"],
+    assert query_resp.json() == [
+        {"id": 1, "subid": 1, "name": "Alice"},
+        {"id": 2, "subid": 1, "name": "Bobby"},
+        {"id": 3, "subid": 1, "name": "Charlie"},
     ]
 


### PR DESCRIPTION
## Summary
- Simplify `/query` endpoint to return rows as an array of objects
- Adjust tests for new response format and document the change

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f9564ae9c8324a72b04a12fcf534f