### PR TITLE
Add bearer token authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ This is a minimal FastAPI application that exposes a RESTful interface for execu
 
 - `DATABASE_PATH` – Path to a DuckDB file on a persistent Railway volume.
 - `MOTHERDUCK_TOKEN` – Authentication token for MotherDuck connections.
+- `API_TOKENS` – Comma-separated list of allowed bearer tokens. Tokens may
+  optionally include a database path using the format `token:db_path` to enable
+  future per-token database routing.
 
 ## Deployment on Railway
 

--- a/app/auth.py
+++ b/app/auth.py
@@ -1,0 +1,74 @@
+import os
+from dataclasses import dataclass
+from typing import Optional, Dict
+
+from fastapi import Depends, HTTPException
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+
+@dataclass
+class AuthContext:
+    """Holds authentication details for a request.
+
+    Additional attributes like database routing information or row-level
+    security rules can be added here in the future.
+    """
+
+    token: str
+    db_path: Optional[str] = None
+
+    def rewrite_query(self, sql: str) -> str:  # pragma: no cover - placeholder
+        """Rewrite a SQL query for row-level security.
+
+        Currently a no-op but designed for future enhancements where the
+        query might be amended based on the authentication context.
+        """
+
+        return sql
+
+
+bearer_scheme = HTTPBearer(auto_error=False)
+
+
+def _load_token_map() -> Dict[str, Dict[str, Optional[str]]]:
+    """Return a mapping of allowed tokens to metadata.
+
+    The `API_TOKENS` environment variable is a comma-separated list of tokens
+    with optional database paths using the format `token:db_path`.
+    Example::
+
+        API_TOKENS="alpha:/data/a.duckdb,beta"
+
+    yields::
+
+        {
+            "alpha": {"db_path": "/data/a.duckdb"},
+            "beta": {"db_path": None},
+        }
+    """
+
+    raw = os.getenv("API_TOKENS", "")
+    mapping: Dict[str, Dict[str, Optional[str]]] = {}
+    for item in raw.split(","):
+        item = item.strip()
+        if not item:
+            continue
+        if ":" in item:
+            token, db_path = item.split(":", 1)
+            mapping[token] = {"db_path": db_path}
+        else:
+            mapping[item] = {"db_path": None}
+    return mapping
+
+
+def get_auth_context(
+    credentials: HTTPAuthorizationCredentials = Depends(bearer_scheme),
+) -> AuthContext:
+    """Validate the bearer token and return an authentication context."""
+
+    token_map = _load_token_map()
+    if credentials is None or credentials.credentials not in token_map:
+        raise HTTPException(status_code=401, detail="Invalid or missing token")
+    info = token_map[credentials.credentials]
+    return AuthContext(token=credentials.credentials, db_path=info.get("db_path"))
+

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,7 +4,10 @@ from fastapi.testclient import TestClient
 
 from app.main import app
 
-client = TestClient(app)
+TOKEN = "testtoken"
+os.environ["API_TOKENS"] = TOKEN
+
+client = TestClient(app, headers={"Authorization": f"Bearer {TOKEN}"})
 
 
 def test_query_duckdb():
@@ -153,4 +156,10 @@ def test_upload_trims_padded_columns(tmp_path):
         {"id": 1, "name": "Alice"},
         {"id": 2, "name": "Bob"},
     ]
+
+
+def test_requires_authentication():
+    unauth_client = TestClient(app)
+    response = unauth_client.post("/query", json={"sql": "SELECT 1"})
+    assert response.status_code == 401
 


### PR DESCRIPTION
## Summary
- add `AuthContext` and bearer token parsing via `API_TOKENS`
- require bearer auth for query and upload endpoints with future hooks for DB routing and row-level security
- document `API_TOKENS` env var and test auth requirement

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68914d0f6d5083248bce19bc3dcc57a5